### PR TITLE
feat: support `WITHOUT ROWID`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ const testTable = defineTable({
   createAt: true, // `createTime` column
   updateAt: true, // `updateTime` column
   softDelete: true, // `isDeleted` column
+  withoutRowId: true, // disable implicit rowId
 })
 
 const DBSchema = {

--- a/src/schema/define.ts
+++ b/src/schema/define.ts
@@ -53,6 +53,7 @@ type ParseFalseToNull<T extends boolean | string | null> = T extends false ? nul
  *   createAt: true, // `createTime` column
  *   updateAt: true, // `updateTime` column
  *   softDelete: true, // `isDeleted` column
+ *   withoutRowId: true, // disables implicit rowId
  * })
  */
 export function defineTable<

--- a/src/schema/run.ts
+++ b/src/schema/run.ts
@@ -101,7 +101,7 @@ export function createTableIndex(
 export function createTable(
   trx: Kysely<any> | Transaction<any>,
   tableName: string,
-  { columns, primary, unique }: Omit<Table, 'index'>,
+  { columns, primary, unique, withoutRowId }: Omit<Table, 'index'>,
 ): { updateColumn?: string, sql: string } {
   let updateColumn
   let autoIncrementColumn
@@ -145,8 +145,10 @@ export function createTable(
     }
   }
 
+  const rowIdClause = withoutRowId ? ' WITHOUT ROWID' : ''
+
   return {
-    sql: `CREATE TABLE IF NOT EXISTS "${tableName}" (${columnList});`,
+    sql: `CREATE TABLE IF NOT EXISTS "${tableName}" (${columnList})${rowIdClause};`,
     updateColumn,
   }
 }

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -65,6 +65,13 @@ export type ExtraOptions<Create, Update, Delete> = {
    * - If type is `string`, it will be treated as column name
    */
   softDelete?: Delete
+  /**
+   * Disable implicit rowId
+   *
+   * - If type is `true`, disable implicit rowId
+   * - If type is `false`, enable implicit rowId
+   */
+  withoutRowId?: boolean
 }
 
 export type TableProperty<


### PR DESCRIPTION
Add table definition support for the [WITHOUT ROWID](https://www.sqlite.org/withoutrowid.html) optimization for non-integer primary keys.

Feel free to close if out of scope / creep.